### PR TITLE
Translationable in t.w.org

### DIFF
--- a/c3-cloudfront-clear-cache.php
+++ b/c3-cloudfront-clear-cache.php
@@ -6,7 +6,7 @@ Plugin URI:https://github.com/megumiteam/C3-Cloudfront-Clear-Cache
 Description:This is simple plugin that clear all cloudfront cache if you publish posts.
 Author: hideokamoto
 Author URI: http://wp-kyoto.net/
-Text Domain: c3_cloudfront_clear_cache
+Text Domain: c3-cloudfront-clear-cache
 */
 require_once( dirname( __FILE__ ).'/aws.phar' );
 require_once( dirname( __FILE__ ).'/lib/c3-admin.php' );

--- a/lib/c3-admin.php
+++ b/lib/c3-admin.php
@@ -114,6 +114,7 @@ class CloudFront_Clear_Cache_Admin {
 	public function c3_admin_init() {
 		$option_name = CloudFront_Clear_Cache::OPTION_NAME;
 		$nonce_key = CloudFront_Clear_Cache::OPTION_NAME;
+		load_plugin_textdomain( self::$text_domain );
 		if ( isset ( $_POST[ self::MENU_ID ] ) && $_POST[ self::MENU_ID ] ) {
 			if ( check_admin_referer( $nonce_key , self::MENU_ID ) ) {
 				$e = new WP_Error();
@@ -123,6 +124,7 @@ class CloudFront_Clear_Cache_Admin {
 			}
 			wp_safe_redirect( menu_page_url( self::MENU_ID , false ) );
 		}
+
 		if ( isset ( $_POST[ self::FLUSH_CACHE ] ) && $_POST[ self::FLUSH_CACHE ] ) {
 			$c3 = CloudFront_Clear_Cache::get_instance();
 			$c3->c3_invalidation();

--- a/lib/c3-admin.php
+++ b/lib/c3-admin.php
@@ -114,7 +114,6 @@ class CloudFront_Clear_Cache_Admin {
 	public function c3_admin_init() {
 		$option_name = CloudFront_Clear_Cache::OPTION_NAME;
 		$nonce_key = CloudFront_Clear_Cache::OPTION_NAME;
-		load_plugin_textdomain( self::$text_domain );
 		if ( isset ( $_POST[ self::MENU_ID ] ) && $_POST[ self::MENU_ID ] ) {
 			if ( check_admin_referer( $nonce_key , self::MENU_ID ) ) {
 				$e = new WP_Error();
@@ -129,6 +128,8 @@ class CloudFront_Clear_Cache_Admin {
 			$c3 = CloudFront_Clear_Cache::get_instance();
 			$c3->c3_invalidation();
 		}
+
+		load_plugin_textdomain( self::$text_domain );
 
 	}
 

--- a/tests/test-c3-settup.php
+++ b/tests/test-c3-settup.php
@@ -3,7 +3,7 @@ class C3_Settup_test extends CloudFront_Clear_Cache_Test {
 
 	function test_load_text_domain() {
 		$text_domain = $this->C3->text_domain();
-		$this->assertEquals( 'c3_cloudfront_clear_cache' , $text_domain );
+		$this->assertEquals( 'c3-cloudfront-clear-cache' , $text_domain );
 	}
 
 	function test_load_current_version() {


### PR DESCRIPTION
- require: `load_plugin_textdomain`.
- require: the textdomain of plugin must be same as plugin slug

see: [WordPress › Plugin Translations on WordPress.org – Make WordPress Plugins](https://make.wordpress.org/plugins/2015/09/01/plugin-translations-on-wordpress-org/)